### PR TITLE
Refactor release process in CI workflow to use Release Bot

### DIFF
--- a/.github/workflows/ci-push-main.yml
+++ b/.github/workflows/ci-push-main.yml
@@ -105,15 +105,25 @@ jobs:
           PR_URL: ${{ steps.changesets.outputs.pull_request_url }}
           GITHUB_TOKEN: ${{ secrets.STUDIOCMS_SERVICE_TOKEN }}
 
-      - name: Generate Announcement
-        id: message
-        if: steps.changesets.outputs.published == 'true'
-        run: node .github/scripts/announce.mjs '${{ steps.changesets.outputs.publishedPackages }}'
-
-      - name: Send message on Discord
-        if: steps.changesets.outputs.published == 'true'
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASE }}
-        uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9 # 0.3.2
+      - name: Release Bot
+        if: ${{ steps.changesets.outputs.published == 'true' }}
+        uses: withstudiocms/automations/.github/actions/releasebot@main
         with:
-          args: "${{ steps.message.outputs.DISCORD_MESSAGE }}"
+          repository: withstudiocms/web-vitals
+          CWD: ${{ github.workspace }}
+          PublishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASE }}
+          RoleMentionId: 1309310416362537020
+
+      # - name: Generate Announcement
+      #   id: message
+      #   if: steps.changesets.outputs.published == 'true'
+      #   run: node .github/scripts/announce.mjs '${{ steps.changesets.outputs.publishedPackages }}'
+
+      # - name: Send message on Discord
+      #   if: steps.changesets.outputs.published == 'true'
+      #   env:
+      #     DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASE }}
+      #   uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9 # 0.3.2
+      #   with:
+      #     args: "${{ steps.message.outputs.DISCORD_MESSAGE }}"

--- a/.github/workflows/ci-push-main.yml
+++ b/.github/workflows/ci-push-main.yml
@@ -113,7 +113,7 @@ jobs:
           CWD: ${{ github.workspace }}
           PublishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASE }}
-          RoleMentionId: 1309310416362537020
+          RoleMentionId: '1309310416362537020'
 
       # - name: Generate Announcement
       #   id: message

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -4,8 +4,11 @@ const config: KnipConfig = {
 	exclude: ['duplicates', 'optionalPeerDependencies'],
 	workspaces: {
 		'.': {
-			ignoreDependencies: ['@changesets/config'],
+			ignoreDependencies: ['@changesets/config', 'tinyglobby'],
 			entry: ['.github/workflows/*.yml'],
+			ignore: [
+				'.github/scripts/*.mjs'
+			]
 		},
 		'packages/test-scripts': {
 			entry: ['cmd/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}', 'index.{js,cjs,mjs,jsx,ts,cts,mts,tsx}'],


### PR DESCRIPTION
This pull request updates the release announcement workflow in `.github/workflows/ci-push-main.yml` to use a custom Release Bot action instead of the previous Discord announcement steps. The main change streamlines the release process and centralizes announcement handling.

**Release process improvements:**

* Replaced the manual Discord announcement steps (`Generate Announcement` and `Send message on Discord`) with a single `Release Bot` action (`withstudiocms/automations/.github/actions/releasebot@main`), which now handles publishing release messages to Discord and includes additional parameters for repository, working directory, published packages, webhook, and role mention.

**Code maintenance:**

* Commented out the old announcement and Discord message steps to preserve them for reference, but they are no longer executed in the workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release notification process to use a unified Release Bot step for Discord announcements.
  * Adjusted dependency analysis configuration to ignore "tinyglobby" and exclude certain script files from checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->