### PR TITLE
Update @astrojs/db dependency to version 0.17.1 in pnpm-lock and pnpm…

### DIFF
--- a/.changeset/eager-walls-cut.md
+++ b/.changeset/eager-walls-cut.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/web-vitals": patch
+---
+
+Patch astrodb dep

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@astrojs/db':
-      specifier: ^0.17.0
-      version: 0.17.0
+      specifier: ^0.17.1
+      version: 0.17.1
     '@astrojs/node':
       specifier: ^9.3.3
       version: 9.3.3
@@ -71,7 +71,7 @@ importers:
     devDependencies:
       '@astrojs/db':
         specifier: 'catalog:'
-        version: 0.17.0
+        version: 0.17.1
       '@inox-tools/astro-tests':
         specifier: 'catalog:'
         version: 0.7.0(astro@5.12.8(@types/node@24.0.10)(jiti@2.4.2)(rollup@4.44.2)(typescript@5.8.3))
@@ -86,7 +86,7 @@ importers:
     dependencies:
       '@astrojs/db':
         specifier: 'catalog:'
-        version: 0.17.0
+        version: 0.17.1
       '@astrojs/node':
         specifier: 'catalog:'
         version: 9.3.3(astro@5.12.8(@types/node@24.0.10)(jiti@2.4.2)(rollup@4.44.2)(typescript@5.8.3))
@@ -102,8 +102,8 @@ packages:
   '@astrojs/compiler@2.12.2':
     resolution: {integrity: sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw==}
 
-  '@astrojs/db@0.17.0':
-    resolution: {integrity: sha512-nS7ma+uzi3pfGJxsrEIF5BhLMJAj79GD5tHcd4jMc8NMmk4yiMU0x1YPBnSWe+yAOX9ARKN+dISw8iM2VZzkCg==}
+  '@astrojs/db@0.17.1':
+    resolution: {integrity: sha512-QL09xZf5Om8AshIlt+YhLDYf6M1QSzv+kfuljsPrhEXJ8U/tuKnbWs2M3wimFaLG3/fU0prFix8lWt7zU8ytfA==}
 
   '@astrojs/internal-helpers@0.6.1':
     resolution: {integrity: sha512-l5Pqf6uZu31aG+3Lv8nl/3s4DbUzdlxTWDof4pEpto6GUJNhhCbelVi9dEyurOVyqaelwmS9oSyOWOENSfgo9A==}
@@ -2613,7 +2613,7 @@ snapshots:
 
   '@astrojs/compiler@2.12.2': {}
 
-  '@astrojs/db@0.17.0':
+  '@astrojs/db@0.17.1':
     dependencies:
       '@libsql/client': 0.15.9
       deep-diff: 1.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 catalog:
   '@types/node': ^22.0.0
-  '@astrojs/db': ^0.17.0
+  '@astrojs/db': ^0.17.1
   '@astrojs/node': ^9.3.3
   '@inox-tools/astro-tests': ^0.7.0
   astro: ^5.12.8


### PR DESCRIPTION
This pull request updates the `@astrojs/db` dependency from version 0.17.0 to 0.17.1 across the codebase to ensure compatibility with the latest patch release. The change is reflected in all relevant configuration and lock files, and a changeset is added to document the update.

**Dependency Update:**

* Updated the `@astrojs/db` version from 0.17.0 to 0.17.1 in `pnpm-workspace.yaml` and all relevant sections of `pnpm-lock.yaml`, including `catalogs`, `importers`, `packages`, and `snapshots`. [[1]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL3-R3) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-R11) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL74-R74) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL89-R89) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL105-R106) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2616-R2616)

**Documentation:**

* Added a changeset file `.changeset/eager-walls-cut.md` to record the patch update for `@studiocms/web-vitals` due to the `astrodb` dependency patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version constraint for a dependency to ensure compatibility and stability.
  * Added a changeset to document the patch update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->